### PR TITLE
Added BoxKey, LeagueTournament, Tournament, serializers

### DIFF
--- a/march_forever_api/models/box.py
+++ b/march_forever_api/models/box.py
@@ -3,6 +3,6 @@ from .team import Team
 from .bracket import Bracket
 
 class Box(models.Model):
-  bracket_id = models.ForeignKey(Bracket, on_delete=models.CASCADE)
-  team_id = models.ForeignKey(Team, on_delete=models.CASCADE)
+  bracket_id = models.ForeignKey(Bracket, on_delete=models.CASCADE, related_name='content')
   code = models.CharField(max_length=4)
+  team_id = models.ForeignKey(Team, on_delete=models.CASCADE)

--- a/march_forever_api/models/box_key.py
+++ b/march_forever_api/models/box_key.py
@@ -1,0 +1,8 @@
+from django.db import models
+from .tournament import Tournament
+from .team import Team
+
+class BoxKey(models.Model):
+  tournament_id = models.ForeignKey(Tournament, on_delete=models.CASCADE, related_name='key')
+  code = models.CharField(max_length=4)
+  team_id = models.ForeignKey(Team, on_delete=models.CASCADE)

--- a/march_forever_api/models/bracket.py
+++ b/march_forever_api/models/bracket.py
@@ -1,8 +1,10 @@
 from django.db import models
 from .box import Box
+from .league_tournament import LeagueTournament
 from .user import User
 
 class Bracket(models.Model):
-  user_id = models.ForeignKey(User, on_delete=models.CASCADE)
+  name = models.CharField(max_length=100)
+  user_id = models.ForeignKey(User, on_delete=models.CASCADE, related_name='brackets')
+  league_tournament_id = models.ForeignKey(LeagueTournament, on_delete=models.CASCADE, related_name='brackets')
   points = models.IntegerField(default=0)
-  key = models.BooleanField(default=False)

--- a/march_forever_api/models/league.py
+++ b/march_forever_api/models/league.py
@@ -1,7 +1,10 @@
 from django.db import models
 from .user import User
+from .tournament import Tournament
 
 class League(models.Model):
   name = models.CharField(max_length=255)
   password = models.CharField(max_length=255)
   admin_id = models.ForeignKey(User, on_delete=models.CASCADE)
+  users = models.ManyToManyField(User, through="UserLeague", related_name="leagues")
+  tournaments = models.ManyToManyField(Tournament, through="LeagueTournament", related_name="leagues")

--- a/march_forever_api/models/league_tournament.py
+++ b/march_forever_api/models/league_tournament.py
@@ -1,0 +1,8 @@
+from django.db import models
+from .league import League
+from .tournament import Tournament
+
+class LeagueTournament(models.Model):
+  league_id = models.ForeignKey(League, on_delete=models.CASCADE)
+  tournament_id = models.ForeignKey(Tournament, on_delete=models.CASCADE)
+  brackets_per_user = models.IntegerField(default=1)

--- a/march_forever_api/models/legacy_bracket.py
+++ b/march_forever_api/models/legacy_bracket.py
@@ -1,11 +1,10 @@
 from django.db import models
-from .league import League
+from .league_tournament import LeagueTournament
 from .team import Team
 from .user import User
 
 class LegacyBracket(models.Model):
-  user_id = models.ForeignKey(User, on_delete=models.CASCADE)
-  league_id = models.ForeignKey(League, on_delete=models.CASCADE)
+  user_id = models.ForeignKey(User, on_delete=models.CASCADE, related_name='legacy_brackets')
+  league_tournament_id = models.ForeignKey(LeagueTournament, on_delete=models.CASCADE, related_name='legacy_brackets')
   champion_id = models.ForeignKey(Team, on_delete=models.CASCADE)
   points = models.IntegerField(default=0)
-  key = models.BooleanField(default=False)

--- a/march_forever_api/models/tournament.py
+++ b/march_forever_api/models/tournament.py
@@ -1,0 +1,9 @@
+from django.db import models
+
+class Tournament(models.Model):
+  name = models.CharField(max_length=255)
+  submission_open = models.BooleanField(default=False)
+  start_date = models.DateTimeField()
+  end_date = models.DateTimeField()
+  key_type = models.CharField(max_length=100, default='T64R4')
+  max_points = models.IntegerField(default=0)

--- a/march_forever_api/models/user.py
+++ b/march_forever_api/models/user.py
@@ -4,3 +4,4 @@ class User(models.Model):
   username = models.CharField(max_length=255)
   password = models.CharField(max_length=255)
   joined_on = models.DateTimeField(auto_now_add=True)
+  system_admin = models.BooleanField(default=False)

--- a/march_forever_api/models/user_league.py
+++ b/march_forever_api/models/user_league.py
@@ -6,4 +6,4 @@ class UserLeague(models.Model):
   user_id = models.ForeignKey(User, on_delete=models.CASCADE)
   league_id = models.ForeignKey(League, on_delete=models.CASCADE)
   joined_on = models.DateTimeField(auto_now_add=True)
-  retired = models.BooleanField(default=False)
+  retired_on = models.DateTimeField(null=True)

--- a/march_forever_api/serializers.py
+++ b/march_forever_api/serializers.py
@@ -1,0 +1,52 @@
+from rest_framework import serializers
+from .models import Box, BoxKey, Bracket, League, LeagueTournament, LegacyBracket, Team, Tournament, UserLeague, User
+
+class BoxSerializer(serializers.ModelSerializer):
+  class Meta:
+    model = Box
+    fields = ['bracket_id', 'team_id', 'code']
+
+class BoxKeySerializer(serializers.ModelSerializer):
+  class Meta:
+    model = BoxKey
+    fields = ['tournament_id', 'team_id', 'code']
+
+class BracketSerializer(serializers.ModelSerializer):
+  class Meta:
+    model = Bracket
+    fields = ['name', 'user_id', 'points', 'league_tournament_id', 'content']
+
+class LeagueSerializer(serializers.ModelSerializer):
+  class Meta:
+    model = League
+    fields = ['name', 'password', 'admin_id', 'brackets', 'users', 'legacy_brackets', 'tournaments']
+
+class LeagueTournamentSerializer(serializers.ModelSerializer):
+  class Meta:
+    model = LeagueTournament
+    fields = ['league_id', 'tournament_id', 'brackets_per_user']
+
+class LegacyBracketSerializer(serializers.ModelSerializer):
+  class Meta:
+    model = LegacyBracket
+    fields = ['user_id', 'league_tournament_id', 'champion_id', 'points']
+
+class TeamSerializer(serializers.ModelSerializer):
+  class Meta:
+    model = Team
+    fields = ['school', 'nickname', 'abbreviation', 'logo_url', 'color_primary_hex', 'color_secondary_hex']
+
+class TournamentSerializer(serializers.ModelSerializer):
+  class Meta:
+    model = Tournament
+    fields = ['name', 'submission_open', 'start_date', 'end_date', 'key_type', 'max_points', 'key']
+
+class UserLeagueSerializer(serializers.ModelSerializer):
+  class Meta:
+    model = UserLeague
+    fields = ['user_id', 'league_id', 'joined_on', 'retired_on']
+
+class UserSerializer(serializers.ModelSerializer):
+  class Meta:
+    model = User
+    fields = ['username', 'password', 'joined_on', 'system_admin', 'brackets', 'legacy_brackets', 'leagues']


### PR DESCRIPTION
Created Tournament entity which allows for multiple leagues to be set up surrounding a single tournament, as well as a single league to be part of multiple tournaments (via LeagueTournament join entity, the entity to which brackets are added). The BoxKey model is the same as the Box model, except it appends to the Tournament class and holds information for the Tournament Key. Tournament has a "key_type" property that describes how the tournament is structured; defaults to T64R4 (64 teams with 4 regions).

Created serializers for all existing models.